### PR TITLE
Test on node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '8'
   - '7'
 before_script:
   - npm prune


### PR DESCRIPTION
Node 8 is LTS now, Node 7 is a develop version which is no longer supported.

Currently failing as a result of https://github.com/philippschulte/fastly-promises/issues/1.