### PR TITLE
Added 2 new endpoints for WAF( Web Application Firewall)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 /* Istanbul */
 /coverage
+/*Local files */
+src/.env
+.idea/
+inputBody.json

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cz-conventional-changelog": "2.0.0",
     "expect": "1.20.2",
     "ghooks": "2.0.0",
-    "istanbul": "^0.4.5",
+    "istanbul": "0.4.5",
     "mocha": "3.5.0",
     "nock": "9.1.6",
     "semantic-release": "^6.3.6"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "semantic-release": "^6.3.6"
   },
   "dependencies": {
-    "axios": "0.16.2"
+    "axios": "0.16.2",
+    "dotenv": "^4.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "cz-conventional-changelog": "2.0.0",
     "expect": "1.20.2",
     "ghooks": "2.0.0",
-    "istanbul": "0.4.5",
+    "istanbul": "^0.4.5",
     "mocha": "3.5.0",
-    "nock": "9.0.14",
+    "nock": "9.1.6",
     "semantic-release": "^6.3.6"
   },
   "dependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,15 @@
 'use strict';
 
 module.exports = {
-  mainEntryPoint: 'https://api.fastly.com'
+    mainEntryPoint: 'https://api.fastly.com',
+    WAFTags: ["OWASP",
+        "language-html",
+        "language-htm",
+        "language-css",
+        "language-json",
+        "language-jpg",
+        "language-java",
+        "reputation-Malicious IP",
+        "reputation-Tor Exit Node",
+        "application-Wordpress"]
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,15 +1,15 @@
 'use strict';
 
 module.exports = {
-    mainEntryPoint: 'https://api.fastly.com',
-    WAFTags: ["OWASP",
-        "language-html",
-        "language-htm",
-        "language-css",
-        "language-json",
-        "language-jpg",
-        "language-java",
-        "reputation-Malicious IP",
-        "reputation-Tor Exit Node",
-        "application-Wordpress"]
+  mainEntryPoint: 'https://api.fastly.com',
+  WAFTags: ["OWASP",
+    "language-html",
+    "language-htm",
+    "language-css",
+    "language-json",
+    "language-jpg",
+    "language-java",
+    "reputation-Malicious IP",
+    "reputation-Tor Exit Node",
+    "application-Wordpress"]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Fastly {
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
       timeout: 3000,
-      headers: {'Fastly-Key': token}
+      headers: { 'Fastly-Key': token }
     });
   }
 
@@ -50,7 +50,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
   }
 
   /**
@@ -68,7 +68,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Fastly {
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
       timeout: 3000,
-      headers: {'Fastly-Key': token}
+      headers: { 'Fastly-Key': token }
     });
   }
 
@@ -50,7 +50,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
   }
 
   /**
@@ -68,7 +68,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
   }
 
   /**
@@ -188,7 +188,17 @@ class Fastly {
     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[status]=${wafStatus}&page[size]=200&page[number]=${pageNumber}`)
   }
 
-
+  /**
+   * Gets the WAF Rules associated with a service dependant on WAF tags.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param tag {string} The WAF tag whose rules are enabled on a service.
+   * @return {Promise} The response object representing the completion or failure.
+   * @param pageNumber {number} Page number for the of the results output.
+   * @return {Promise} An array of response object(s) representing the completion or failure.
+   */
+  getWafRulesByTags(wafId = '', tag = '', pageNumber = '') {
+      return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+  }
   /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
    * @param wafId {string} The WAF ID associated with a service.
@@ -221,7 +231,6 @@ class Fastly {
         }
       });
     });
-    //console.log(axios.all(tagRequests));
     return axios.all(tagRequests); //returns an array of responses(Type : object)
   }
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -182,19 +182,23 @@ class Fastly {
    * @param wafId {string} The WAF ID associated with a service.
    * @param status {String} Can be log, block or disable.
    * @param tags {Array} Optional. Updates all tags by default.
-   * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
+   * @param forceToggle {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
    * @return {Promise} An array of response object(s) representing the completion or failure.
    */
 
-  updateTags(wafId = '', status = '', tags = config.WAFTags, force = false) {
+  updateTags(wafId = '', status = '', tags = config.WAFTags, forceToggle = false) {
     const tagRequests = tags.map((tag) => {
       const data = {
         "data": {
+          "attributes": {
+            "name": tag,
+            "status": status
+          },
           "type": "rule_status",
-          "id": wafId,
-          "attributes": {"name": tag, "status": status, "force": force}
+          "id": wafId
         }
       };
+      if (forceToggle === true) data.data.attributes.force = true;
       //Override timeout for this request as it's known to take a long time- updates every rule in the tag one by one
       return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
         timeout: 30000,

--- a/src/index.js
+++ b/src/index.js
@@ -4,201 +4,201 @@ const axios = require('axios');
 const config = require('./config');
 
 class Fastly {
-    /**
-     * The constructor method for creating a fastly-promises instance.
-     * @param token {String} The Fastly API token.
-     * @param service_id {String} The Fastly service ID.
-     */
-    constructor(token, service_id) {
-        this.service_id = service_id;
-        this.request = axios.create({
-            baseURL: config.mainEntryPoint,
-            timeout: 3000,
-            headers: {'Fastly-Key': token}
-        });
-    }
+		/**
+		 * The constructor method for creating a fastly-promises instance.
+		 * @param token {String} The Fastly API token.
+		 * @param service_id {String} The Fastly service ID.
+		 */
+		constructor(token, service_id) {
+				this.service_id = service_id;
+				this.request = axios.create({
+						baseURL: config.mainEntryPoint,
+						timeout: 3000,
+						headers: {'Fastly-Key': token}
+				});
+		}
 
-    /**
-     * Instant Purge an individual URL.
-     * @param url {String} The URL to purge.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    purgeIndividual(url = '') {
-        return this.request.post(`/purge/${url}`);
-    }
+		/**
+		 * Instant Purge an individual URL.
+		 * @param url {String} The URL to purge.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		purgeIndividual(url = '') {
+				return this.request.post(`/purge/${url}`);
+		}
 
-    /**
-     * Instant Purge everything from a service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    purgeAll() {
-        return this.request.post(`/service/${this.service_id}/purge_all`);
-    }
+		/**
+		 * Instant Purge everything from a service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		purgeAll() {
+				return this.request.post(`/service/${this.service_id}/purge_all`);
+		}
 
-    /**
-     * Instant Purge a particular service of items tagged with a Surrogate Key.
-     * @param key {String} The surrogate key to purge.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    purgeKey(key = '') {
-        return this.request.post(`/service/${this.service_id}/purge/${key}`);
-    }
+		/**
+		 * Instant Purge a particular service of items tagged with a Surrogate Key.
+		 * @param key {String} The surrogate key to purge.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		purgeKey(key = '') {
+				return this.request.post(`/service/${this.service_id}/purge/${key}`);
+		}
 
-    /**
-     * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
-     * @param keys {Array} The array of surrogate keys to purge.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    purgeKeys(keys = []) {
-        return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
-    }
+		/**
+		 * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
+		 * @param keys {Array} The array of surrogate keys to purge.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		purgeKeys(keys = []) {
+				return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+		}
 
-    /**
-     * Soft Purge an individual URL.
-     * @param url {String} The URL to soft purge.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    softPurgeIndividual(url = '') {
-        return this.request.post(`/purge/${url}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
-    }
+		/**
+		 * Soft Purge an individual URL.
+		 * @param url {String} The URL to soft purge.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		softPurgeIndividual(url = '') {
+				return this.request.post(`/purge/${url}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+		}
 
-    /**
-     * Soft Purge a particular service of items tagged with a Surrogate Key.
-     * @param key {String} The surrogate key to soft purge.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    softPurgeKey(key = '') {
-        return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
-    }
+		/**
+		 * Soft Purge a particular service of items tagged with a Surrogate Key.
+		 * @param key {String} The surrogate key to soft purge.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		softPurgeKey(key = '') {
+				return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+		}
 
-    /**
-     * Get a list of all Fastly datacenters.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    dataCenters() {
-        return this.request.get('/datacenters');
-    }
+		/**
+		 * Get a list of all Fastly datacenters.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		dataCenters() {
+				return this.request.get('/datacenters');
+		}
 
-    /**
-     * Fastly's services IP ranges.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    publicIpList() {
-        return this.request.get('/public-ip-list');
-    }
+		/**
+		 * Fastly's services IP ranges.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		publicIpList() {
+				return this.request.get('/public-ip-list');
+		}
 
-    /**
-     * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
-     * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    edgeCheck(url = '') {
-        return this.request.get(`/content/edge_check?url=${url}`);
-    }
+		/**
+		 * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
+		 * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		edgeCheck(url = '') {
+				return this.request.get(`/content/edge_check?url=${url}`);
+		}
 
-    /**
-     * List all services.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    readServices() {
-        return this.request.get(`/service`);
-    }
+		/**
+		 * List all services.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		readServices() {
+				return this.request.get(`/service`);
+		}
 
-    /**
-     * List the versions for a particular service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    readVersions() {
-        return this.request.get(`/service/${this.service_id}/version`);
-    }
+		/**
+		 * List the versions for a particular service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		readVersions() {
+				return this.request.get(`/service/${this.service_id}/version`);
+		}
 
-    /**
-     * Clone the current configuration into a new version.
-     * @param version {String} The version to be cloned.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    cloneVersion(version = '') {
-        return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
-    }
+		/**
+		 * Clone the current configuration into a new version.
+		 * @param version {String} The version to be cloned.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		cloneVersion(version = '') {
+				return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
+		}
 
-    /**
-     * Activate the current version.
-     * @param version {String} The version to be activated.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    activateVersion(version = '') {
-        return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
-    }
+		/**
+		 * Activate the current version.
+		 * @param version {String} The version to be activated.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		activateVersion(version = '') {
+				return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
+		}
 
-    /**
-     * List all the domains for a particular service and version.
-     * @param version {String} The current version of a service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    readDomains(version = '') {
-        return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
-    }
+		/**
+		 * List all the domains for a particular service and version.
+		 * @param version {String} The current version of a service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		readDomains(version = '') {
+				return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
+		}
 
-    /**
-     * List all backends for a particular service and version.
-     * @param version {String} The current version of a service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    readBackends(version = '') {
-        return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
-    }
+		/**
+		 * List all backends for a particular service and version.
+		 * @param version {String} The current version of a service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		readBackends(version = '') {
+				return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
+		}
 
-    /**
-     * Update the backend for a particular service and version.
-     * @param version {String} The current version of a service.
-     * @param name {String} The name of the backend.
-     * @param data {Object} The data to be sent as the request body.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    updateBackend(version = '', name = '', data = {}) {
-        return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
-    }
+		/**
+		 * Update the backend for a particular service and version.
+		 * @param version {String} The current version of a service.
+		 * @param name {String} The name of the backend.
+		 * @param data {Object} The data to be sent as the request body.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		updateBackend(version = '', name = '', data = {}) {
+				return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
+		}
 
-    /**
-     * Checks the status of all domains for a particular service and version.
-     * @param version {String} The current version of a service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    domainCheckAll(version = '') {
-        return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
-    }
+		/**
+		 * Checks the status of all domains for a particular service and version.
+		 * @param version {String} The current version of a service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		domainCheckAll(version = '') {
+				return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
+		}
 
-    /**
-     * Gets the WAFs associated with a service.
-     * @param version {String} The current version of a service.
-     * @return {Promise} The response object representing the completion or failure.
-     */
-    getWAFs(version = '') {
-        return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
-    }
+		/**
+		 * Gets the WAFs associated with a service.
+		 * @param version {String} The current version of a service.
+		 * @return {Promise} The response object representing the completion or failure.
+		 */
+		getWAFs(version = '') {
+				return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
+		}
 
-    /**
-     * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
-     * @param wafId {string} The WAF ID associated with a service.
-     * @param status {String} Can be log, block or disable.
-     * @param tags {Array} Optional. Updates all tags by default.
-     * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
-     * @return {Promise} An array of response object(s) representing the completion or failure.
-     */
+		/**
+		 * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
+		 * @param wafId {string} The WAF ID associated with a service.
+		 * @param status {String} Can be log, block or disable.
+		 * @param tags {Array} Optional. Updates all tags by default.
+		 * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
+		 * @return {Promise} An array of response object(s) representing the completion or failure.
+		 */
 
-    updateTags(wafId = '', status = '', tags = config.WAFTags, force=false) {
-        const tagRequests = tags.map((tag) => {
-            const data = {
-                "data": {
-                    "type": "rule_status",
-                    "id": wafId,
-                    "attributes": {"name": tag, "status": status, "force": force}
-                }
-            };
-            return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {headers: {'Accept': 'application/vnd.api+json','Content-Type':'application/vnd.api+json'}});
-        });
-        return axios.all(tagRequests); //returns an array of responses(Type : object)
-    }
+		updateTags(wafId = '', status = '', tags = config.WAFTags, force=false) {
+				const tagRequests = tags.map((tag) => {
+						const data = {
+								"data": {
+										"type": "rule_status",
+										"id": wafId,
+										"attributes": {"name": tag, "status": status, "force": force}
+								}
+						};
+						return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {headers: {'Accept': 'application/vnd.api+json','Content-Type':'application/vnd.api+json'}});
+				});
+				return axios.all(tagRequests); //returns an array of responses(Type : object)
+		}
 }
 
 /**
@@ -211,5 +211,5 @@ class Fastly {
  * }
  */
 module.exports = (token = '', service_id = '') => {
-    return new Fastly(token, service_id);
+		return new Fastly(token, service_id);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,6 @@ class Fastly {
    * Gets the WAF Rules associated with a service dependant on WAF tags.
    * @param wafId {string} The WAF ID associated with a service.
    * @param tag {string} The WAF tag whose rules are enabled on a service.
-   * @return {Promise} The response object representing the completion or failure.
    * @param pageNumber {number} Page number for the of the results output.
    * @return {Promise} An array of response object(s) representing the completion or failure.
    */

--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,9 @@ class Fastly {
           "attributes": {"name": tag, "status": status, "force": force}
         }
       };
+      //Override timeout for this request as it's known to take a long time- updates every rule in the tag one by one
       return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
+        timeout:30000,
         headers: {
           'Accept': 'application/vnd.api+json',
           'Content-Type': 'application/vnd.api+json'

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,7 @@ class Fastly {
     domainCheckAll(version = '') {
         return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
     }
+
     /**
      * Gets the WAFs associated with a service.
      * @param version {String} The current version of a service.
@@ -174,6 +175,29 @@ class Fastly {
      */
     getWAFs(version = '') {
         return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
+    }
+
+    /**
+     * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
+     * @param wafId {string} The WAF ID associated with a service.
+     * @param status {String} Can be log, block or disable.
+     * @param tags {Array} Optional. Updates all tags by default.
+     * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
+     * @return {Promise} An array of response object(s) representing the completion or failure.
+     */
+
+    updateTags(wafId = '', status = '', tags = config.WAFTags, force=false) {
+        const tagRequests = tags.map((tag) => {
+            const data = {
+                "data": {
+                    "type": "rule_status",
+                    "id": wafId,
+                    "attributes": {"name": tag, "status": status, "force": force}
+                }
+            };
+            return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {headers: {'Accept': 'application/vnd.api+json','Content-Type':'application/vnd.api+json'}});
+        });
+        return axios.all(tagRequests); //returns an array of responses(Type : object)
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ class Fastly {
     return axios.all(tagRequests); //returns an array of responses(Type : object)
   }
   /**
-   *Update rule status(s) for a particular service, firewall, and rule.
+   * Update rule status(s) for a particular service, firewall, and rule.
    * @param wafId {string} The WAF ID associated with a service.
    * @param status {String} Can be log, block or disable.
    * @param rules {Array} A string of ruleIDs, can be between 1-**.
@@ -261,6 +261,26 @@ class Fastly {
       });
     });
     return axios.all(ruleIds); //returns an array of responses(Type : object)
+  }
+
+  /**
+   * Activate changes to your WAF config by running a patch request on the ruleset endpoint.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @return {Promise} An array of response object(s) representing the completion or failure.
+   */
+
+  deployChangesForWAF(wafId = '') {
+    const data = {
+      "data": {
+        "type": "ruleset",
+        "id": wafId,
+      }
+    };
+    return this.request.patch(`/service/${this.service_id}/wafs/${wafId}/ruleset`, data, {
+      headers: {
+        'Content-Type': 'application/vnd.api+json'
+      }
+    });
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,169 +4,177 @@ const axios = require('axios');
 const config = require('./config');
 
 class Fastly {
-  /**
-   * The constructor method for creating a fastly-promises instance.
-   * @param token {String} The Fastly API token.
-   * @param service_id {String} The Fastly service ID.
-   */
-  constructor(token, service_id) {
-    this.service_id = service_id;
-    this.request = axios.create({
-      baseURL: config.mainEntryPoint,
-      timeout: 3000,
-      headers: { 'Fastly-Key': token }
-    });
-  }
+    /**
+     * The constructor method for creating a fastly-promises instance.
+     * @param token {String} The Fastly API token.
+     * @param service_id {String} The Fastly service ID.
+     */
+    constructor(token, service_id) {
+        this.service_id = service_id;
+        this.request = axios.create({
+            baseURL: config.mainEntryPoint,
+            timeout: 3000,
+            headers: {'Fastly-Key': token}
+        });
+    }
 
-  /**
-   * Instant Purge an individual URL.
-   * @param url {String} The URL to purge.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  purgeIndividual(url = '') {
-    return this.request.post(`/purge/${url}`);
-  }
+    /**
+     * Instant Purge an individual URL.
+     * @param url {String} The URL to purge.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    purgeIndividual(url = '') {
+        return this.request.post(`/purge/${url}`);
+    }
 
-  /**
-   * Instant Purge everything from a service.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  purgeAll() {
-    return this.request.post(`/service/${this.service_id}/purge_all`);
-  }
+    /**
+     * Instant Purge everything from a service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    purgeAll() {
+        return this.request.post(`/service/${this.service_id}/purge_all`);
+    }
 
-  /**
-   * Instant Purge a particular service of items tagged with a Surrogate Key.
-   * @param key {String} The surrogate key to purge.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  purgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`);
-  }
+    /**
+     * Instant Purge a particular service of items tagged with a Surrogate Key.
+     * @param key {String} The surrogate key to purge.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    purgeKey(key = '') {
+        return this.request.post(`/service/${this.service_id}/purge/${key}`);
+    }
 
-  /**
-   * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
-   * @param keys {Array} The array of surrogate keys to purge.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
-  }
+    /**
+     * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
+     * @param keys {Array} The array of surrogate keys to purge.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    purgeKeys(keys = []) {
+        return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+    }
 
-  /**
-   * Soft Purge an individual URL.
-   * @param url {String} The URL to soft purge.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  softPurgeIndividual(url = '') {
-    return this.request.post(`/purge/${url}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
-  }
+    /**
+     * Soft Purge an individual URL.
+     * @param url {String} The URL to soft purge.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    softPurgeIndividual(url = '') {
+        return this.request.post(`/purge/${url}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+    }
 
-  /**
-   * Soft Purge a particular service of items tagged with a Surrogate Key.
-   * @param key {String} The surrogate key to soft purge.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
-  }
+    /**
+     * Soft Purge a particular service of items tagged with a Surrogate Key.
+     * @param key {String} The surrogate key to soft purge.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    softPurgeKey(key = '') {
+        return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+    }
 
-  /**
-   * Get a list of all Fastly datacenters.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  dataCenters() {
-    return this.request.get('/datacenters');
-  }
+    /**
+     * Get a list of all Fastly datacenters.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    dataCenters() {
+        return this.request.get('/datacenters');
+    }
 
-  /**
-   * Fastly's services IP ranges.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  publicIpList() {
-    return this.request.get('/public-ip-list');
-  }
+    /**
+     * Fastly's services IP ranges.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    publicIpList() {
+        return this.request.get('/public-ip-list');
+    }
 
-  /**
-   * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
-   * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  edgeCheck(url = '') {
-    return this.request.get(`/content/edge_check?url=${url}`);
-  }
-  
-  /**
-   * List all services.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  readServices() {
-    return this.request.get(`/service`);
-  }
-  
-  /**
-   * List the versions for a particular service.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  readVersions() {
-    return this.request.get(`/service/${this.service_id}/version`);
-  }
+    /**
+     * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
+     * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    edgeCheck(url = '') {
+        return this.request.get(`/content/edge_check?url=${url}`);
+    }
 
-  /**
-   * Clone the current configuration into a new version.
-   * @param version {String} The version to be cloned.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  cloneVersion(version = '') {
-    return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
-  }
+    /**
+     * List all services.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    readServices() {
+        return this.request.get(`/service`);
+    }
 
-  /**
-   * Activate the current version.
-   * @param version {String} The version to be activated.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  activateVersion(version = '') {
-    return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
-  }
+    /**
+     * List the versions for a particular service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    readVersions() {
+        return this.request.get(`/service/${this.service_id}/version`);
+    }
 
-  /**
-   * List all the domains for a particular service and version.
-   * @param version {String} The current version of a service.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  readDomains(version = '') {
-    return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
-  }
+    /**
+     * Clone the current configuration into a new version.
+     * @param version {String} The version to be cloned.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    cloneVersion(version = '') {
+        return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
+    }
 
-  /**
-   * List all backends for a particular service and version.
-   * @param version {String} The current version of a service.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  readBackends(version = '') {
-    return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
-  }
+    /**
+     * Activate the current version.
+     * @param version {String} The version to be activated.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    activateVersion(version = '') {
+        return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
+    }
 
-  /**
-   * Update the backend for a particular service and version.
-   * @param version {String} The current version of a service.
-   * @param name {String} The name of the backend.
-   * @param data {Object} The data to be sent as the request body.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  updateBackend(version = '', name = '', data = {}) {
-    return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
-  }
+    /**
+     * List all the domains for a particular service and version.
+     * @param version {String} The current version of a service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    readDomains(version = '') {
+        return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
+    }
 
-  /**
-   * Checks the status of all domains for a particular service and version.
-   * @param version {String} The current version of a service.
-   * @return {Promise} The response object representing the completion or failure.
-   */
-  domainCheckAll(version = '') {
-    return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
-  }
+    /**
+     * List all backends for a particular service and version.
+     * @param version {String} The current version of a service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    readBackends(version = '') {
+        return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
+    }
+
+    /**
+     * Update the backend for a particular service and version.
+     * @param version {String} The current version of a service.
+     * @param name {String} The name of the backend.
+     * @param data {Object} The data to be sent as the request body.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    updateBackend(version = '', name = '', data = {}) {
+        return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
+    }
+
+    /**
+     * Checks the status of all domains for a particular service and version.
+     * @param version {String} The current version of a service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    domainCheckAll(version = '') {
+        return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
+    }
+    /**
+     * Gets the WAFs associated with a service.
+     * @param version {String} The current version of a service.
+     * @return {Promise} The response object representing the completion or failure.
+     */
+    getWAFs(version = '') {
+        return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
+    }
 }
 
 /**
@@ -179,5 +187,5 @@ class Fastly {
  * }
  */
 module.exports = (token = '', service_id = '') => {
-  return new Fastly(token, service_id);
+    return new Fastly(token, service_id);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,18 @@ class Fastly {
   }
 
   /**
+   * Gets the WAF Rules associated with a service dependant on WAF status.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param wafStatus {string} The WAF status associated with a rule (log/block/disabled).
+   * @param pageNumber {number} Page number for the of the results output.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  getWafRules(wafId = '', wafStatus = '', pageNumber = '') {
+    return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[status]=${wafStatus}&page[size]=200&page[number]=${pageNumber}`)
+  }
+
+
+  /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
    * @param wafId {string} The WAF ID associated with a service.
    * @param status {String} Can be log, block or disable.

--- a/src/index.js
+++ b/src/index.js
@@ -4,201 +4,206 @@ const axios = require('axios');
 const config = require('./config');
 
 class Fastly {
-		/**
-		 * The constructor method for creating a fastly-promises instance.
-		 * @param token {String} The Fastly API token.
-		 * @param service_id {String} The Fastly service ID.
-		 */
-		constructor(token, service_id) {
-				this.service_id = service_id;
-				this.request = axios.create({
-						baseURL: config.mainEntryPoint,
-						timeout: 3000,
-						headers: {'Fastly-Key': token}
-				});
-		}
+  /**
+   * The constructor method for creating a fastly-promises instance.
+   * @param token {String} The Fastly API token.
+   * @param service_id {String} The Fastly service ID.
+   */
+  constructor(token, service_id) {
+    this.service_id = service_id;
+    this.request = axios.create({
+      baseURL: config.mainEntryPoint,
+      timeout: 3000,
+      headers: {'Fastly-Key': token}
+    });
+  }
 
-		/**
-		 * Instant Purge an individual URL.
-		 * @param url {String} The URL to purge.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		purgeIndividual(url = '') {
-				return this.request.post(`/purge/${url}`);
-		}
+  /**
+   * Instant Purge an individual URL.
+   * @param url {String} The URL to purge.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  purgeIndividual(url = '') {
+    return this.request.post(`/purge/${url}`);
+  }
 
-		/**
-		 * Instant Purge everything from a service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		purgeAll() {
-				return this.request.post(`/service/${this.service_id}/purge_all`);
-		}
+  /**
+   * Instant Purge everything from a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  purgeAll() {
+    return this.request.post(`/service/${this.service_id}/purge_all`);
+  }
 
-		/**
-		 * Instant Purge a particular service of items tagged with a Surrogate Key.
-		 * @param key {String} The surrogate key to purge.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		purgeKey(key = '') {
-				return this.request.post(`/service/${this.service_id}/purge/${key}`);
-		}
+  /**
+   * Instant Purge a particular service of items tagged with a Surrogate Key.
+   * @param key {String} The surrogate key to purge.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  purgeKey(key = '') {
+    return this.request.post(`/service/${this.service_id}/purge/${key}`);
+  }
 
-		/**
-		 * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
-		 * @param keys {Array} The array of surrogate keys to purge.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		purgeKeys(keys = []) {
-				return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
-		}
+  /**
+   * Instant Purge a particular service of items tagged with Surrogate Keys in a batch.
+   * @param keys {Array} The array of surrogate keys to purge.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  purgeKeys(keys = []) {
+    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+  }
 
-		/**
-		 * Soft Purge an individual URL.
-		 * @param url {String} The URL to soft purge.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		softPurgeIndividual(url = '') {
-				return this.request.post(`/purge/${url}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
-		}
+  /**
+   * Soft Purge an individual URL.
+   * @param url {String} The URL to soft purge.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  softPurgeIndividual(url = '') {
+    return this.request.post(`/purge/${url}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+  }
 
-		/**
-		 * Soft Purge a particular service of items tagged with a Surrogate Key.
-		 * @param key {String} The surrogate key to soft purge.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		softPurgeKey(key = '') {
-				return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
-		}
+  /**
+   * Soft Purge a particular service of items tagged with a Surrogate Key.
+   * @param key {String} The surrogate key to soft purge.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  softPurgeKey(key = '') {
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+  }
 
-		/**
-		 * Get a list of all Fastly datacenters.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		dataCenters() {
-				return this.request.get('/datacenters');
-		}
+  /**
+   * Get a list of all Fastly datacenters.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  dataCenters() {
+    return this.request.get('/datacenters');
+  }
 
-		/**
-		 * Fastly's services IP ranges.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		publicIpList() {
-				return this.request.get('/public-ip-list');
-		}
+  /**
+   * Fastly's services IP ranges.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  publicIpList() {
+    return this.request.get('/public-ip-list');
+  }
 
-		/**
-		 * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
-		 * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		edgeCheck(url = '') {
-				return this.request.get(`/content/edge_check?url=${url}`);
-		}
+  /**
+   * Retrieve headers and MD5 hash of the content for a particular URL from each Fastly edge server.
+   * @param url {String} Full URL (host and path) to check on all nodes. If protocol is omitted, http will be assumed.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  edgeCheck(url = '') {
+    return this.request.get(`/content/edge_check?url=${url}`);
+  }
 
-		/**
-		 * List all services.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		readServices() {
-				return this.request.get(`/service`);
-		}
+  /**
+   * List all services.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  readServices() {
+    return this.request.get(`/service`);
+  }
 
-		/**
-		 * List the versions for a particular service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		readVersions() {
-				return this.request.get(`/service/${this.service_id}/version`);
-		}
+  /**
+   * List the versions for a particular service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  readVersions() {
+    return this.request.get(`/service/${this.service_id}/version`);
+  }
 
-		/**
-		 * Clone the current configuration into a new version.
-		 * @param version {String} The version to be cloned.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		cloneVersion(version = '') {
-				return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
-		}
+  /**
+   * Clone the current configuration into a new version.
+   * @param version {String} The version to be cloned.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  cloneVersion(version = '') {
+    return this.request.put(`/service/${this.service_id}/version/${version}/clone`);
+  }
 
-		/**
-		 * Activate the current version.
-		 * @param version {String} The version to be activated.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		activateVersion(version = '') {
-				return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
-		}
+  /**
+   * Activate the current version.
+   * @param version {String} The version to be activated.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  activateVersion(version = '') {
+    return this.request.put(`/service/${this.service_id}/version/${version}/activate`);
+  }
 
-		/**
-		 * List all the domains for a particular service and version.
-		 * @param version {String} The current version of a service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		readDomains(version = '') {
-				return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
-		}
+  /**
+   * List all the domains for a particular service and version.
+   * @param version {String} The current version of a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  readDomains(version = '') {
+    return this.request.get(`/service/${this.service_id}/version/${version}/domain`);
+  }
 
-		/**
-		 * List all backends for a particular service and version.
-		 * @param version {String} The current version of a service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		readBackends(version = '') {
-				return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
-		}
+  /**
+   * List all backends for a particular service and version.
+   * @param version {String} The current version of a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  readBackends(version = '') {
+    return this.request.get(`/service/${this.service_id}/version/${version}/backend`);
+  }
 
-		/**
-		 * Update the backend for a particular service and version.
-		 * @param version {String} The current version of a service.
-		 * @param name {String} The name of the backend.
-		 * @param data {Object} The data to be sent as the request body.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		updateBackend(version = '', name = '', data = {}) {
-				return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
-		}
+  /**
+   * Update the backend for a particular service and version.
+   * @param version {String} The current version of a service.
+   * @param name {String} The name of the backend.
+   * @param data {Object} The data to be sent as the request body.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  updateBackend(version = '', name = '', data = {}) {
+    return this.request.put(`/service/${this.service_id}/version/${version}/backend/${encodeURIComponent(name)}`, data);
+  }
 
-		/**
-		 * Checks the status of all domains for a particular service and version.
-		 * @param version {String} The current version of a service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		domainCheckAll(version = '') {
-				return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
-		}
+  /**
+   * Checks the status of all domains for a particular service and version.
+   * @param version {String} The current version of a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  domainCheckAll(version = '') {
+    return this.request.get(`/service/${this.service_id}/version/${version}/domain/check_all`);
+  }
 
-		/**
-		 * Gets the WAFs associated with a service.
-		 * @param version {String} The current version of a service.
-		 * @return {Promise} The response object representing the completion or failure.
-		 */
-		getWAFs(version = '') {
-				return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
-		}
+  /**
+   * Gets the WAFs associated with a service.
+   * @param version {String} The current version of a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  getWAFs(version = '') {
+    return this.request.get(`/service/${this.service_id}/version/${version}/wafs`)
+  }
 
-		/**
-		 * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
-		 * @param wafId {string} The WAF ID associated with a service.
-		 * @param status {String} Can be log, block or disable.
-		 * @param tags {Array} Optional. Updates all tags by default.
-		 * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
-		 * @return {Promise} An array of response object(s) representing the completion or failure.
-		 */
+  /**
+   * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param status {String} Can be log, block or disable.
+   * @param tags {Array} Optional. Updates all tags by default.
+   * @param force {boolean} Optional. If set to true,changes the status to the specified mode including previously disabled rules as well. Use with caution
+   * @return {Promise} An array of response object(s) representing the completion or failure.
+   */
 
-		updateTags(wafId = '', status = '', tags = config.WAFTags, force=false) {
-				const tagRequests = tags.map((tag) => {
-						const data = {
-								"data": {
-										"type": "rule_status",
-										"id": wafId,
-										"attributes": {"name": tag, "status": status, "force": force}
-								}
-						};
-						return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {headers: {'Accept': 'application/vnd.api+json','Content-Type':'application/vnd.api+json'}});
-				});
-				return axios.all(tagRequests); //returns an array of responses(Type : object)
-		}
+  updateTags(wafId = '', status = '', tags = config.WAFTags, force = false) {
+    const tagRequests = tags.map((tag) => {
+      const data = {
+        "data": {
+          "type": "rule_status",
+          "id": wafId,
+          "attributes": {"name": tag, "status": status, "force": force}
+        }
+      };
+      return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json'
+        }
+      });
+    });
+    return axios.all(tagRequests); //returns an array of responses(Type : object)
+  }
 }
 
 /**
@@ -211,5 +216,5 @@ class Fastly {
  * }
  */
 module.exports = (token = '', service_id = '') => {
-		return new Fastly(token, service_id);
+  return new Fastly(token, service_id);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -202,15 +202,16 @@ class Fastly {
       //Override timeout for this request as it's known to take a long time- updates every rule in the tag one by one
       return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
         timeout: 30000,
+        validateStatus:null,
         headers: {
           'Accept': 'application/vnd.api+json',
           'Content-Type': 'application/vnd.api+json'
         }
       });
     });
+    //console.log(axios.all(tagRequests));
     return axios.all(tagRequests); //returns an array of responses(Type : object)
   }
-
   /**
    *Update rule status(s) for a particular service, firewall, and rule.
    * @param wafId {string} The WAF ID associated with a service.

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Fastly {
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
       timeout: 3000,
-      headers: { 'Fastly-Key': token }
+      headers: {'Fastly-Key': token}
     });
   }
 
@@ -50,7 +50,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
+    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
   }
 
   /**
@@ -68,7 +68,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
   }
 
   /**
@@ -197,7 +197,7 @@ class Fastly {
       };
       //Override timeout for this request as it's known to take a long time- updates every rule in the tag one by one
       return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
-        timeout:30000,
+        timeout: 30000,
         headers: {
           'Accept': 'application/vnd.api+json',
           'Content-Type': 'application/vnd.api+json'
@@ -205,6 +205,33 @@ class Fastly {
       });
     });
     return axios.all(tagRequests); //returns an array of responses(Type : object)
+  }
+
+  /**
+   *Update rule status(s) for a particular service, firewall, and rule.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param status {String} Can be log, block or disable.
+   * @param rules {Array} A string of ruleIDs, can be between 1-**.
+   * @return {Promise} An array of response object(s) representing the completion or failure.
+   */
+
+  updateRules(wafId = '', status = '', rules = []) {
+    const ruleIds = rules.map((ruleId) => {
+      const data = {
+        "data": {
+          "type": "rule_status",
+          "id": `${wafId}-${ruleId}`,
+          "status": status
+        }
+      };
+      return this.request.patch(`/service/${this.service_id}/wafs/${wafId}/rules/${ruleId}/rule_status`, data, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json'
+        }
+      });
+    });
+    return axios.all(ruleIds); //returns an array of responses(Type : object)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -193,10 +193,12 @@ class Fastly {
    * @param wafId {string} The WAF ID associated with a service.
    * @param tag {string} The WAF tag whose rules are enabled on a service.
    * @param pageNumber {number} Page number for the of the results output.
-   * @return {Promise} An array of response object(s) representing the completion or failure.
+   * @return {Promise} The response object representing the completion or failure.
    */
   getWafRulesByTags(wafId = '', tag = '', pageNumber = '') {
-      return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+      return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`,{
+        timeout:30000
+      })
   }
   /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH

--- a/src/index.js
+++ b/src/index.js
@@ -219,9 +219,11 @@ class Fastly {
     const ruleIds = rules.map((ruleId) => {
       const data = {
         "data": {
+          "attributes": {
+            "status": status
+          },
           "type": "rule_status",
           "id": `${wafId}-${ruleId}`,
-          "status": status
         }
       };
       return this.request.patch(`/service/${this.service_id}/wafs/${wafId}/rules/${ruleId}/rule_status`, data, {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,11 +4,19 @@ const expect = require('expect');
 const config = require('../src/config');
 
 describe('#mainEntryPoint', () => {
-  it('property should exist', () => {
-    expect(config.mainEntryPoint).toExist();
-  });
+    it('property should exist', () => {
+        expect(config.mainEntryPoint).toExist();
+    });
 
-  it('property should be a string', () => {
-    expect(config.mainEntryPoint).toBeA('string');
-  });
+    it('property should be a string', () => {
+        expect(config.mainEntryPoint).toBeA('string');
+    });
+});
+describe('#WAFTags', () => {
+    it('Tags should exist', () => {
+        expect(config.WAFTags).toExist();
+    });
+    it('property should be an array', () => {
+        expect(Array.isArray(config.WAFTags)).toBe(true)
+    });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,19 +4,20 @@ const expect = require('expect');
 const config = require('../src/config');
 
 describe('#mainEntryPoint', () => {
-    it('property should exist', () => {
-        expect(config.mainEntryPoint).toExist();
-    });
+  it('property should exist', () => {
+    expect(config.mainEntryPoint).toExist();
+  });
 
-    it('property should be a string', () => {
-        expect(config.mainEntryPoint).toBeA('string');
-    });
+  it('property should be a string', () => {
+    expect(config.mainEntryPoint).toBeA('string');
+  });
 });
+
 describe('#WAFTags', () => {
-    it('Tags should exist', () => {
-        expect(config.WAFTags).toExist();
-    });
-    it('property should be an array', () => {
-        expect(Array.isArray(config.WAFTags)).toBe(true)
-    });
+  it('Tags should exist', () => {
+    expect(config.WAFTags).toExist();
+  });
+  it('property should be an array', () => {
+    expect(Array.isArray(config.WAFTags)).toBe(true)
+  });
 });

--- a/test/deployChangesForWAF.test.js
+++ b/test/deployChangesForWAF.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/deployChangesForWAF.response.js');
+
+describe('#deployChangesForWAF', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', '79CEhEeP8DKPQQGiXokV5M');
+  let res;
+
+  nock(config.mainEntryPoint)
+   .patch('/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/ruleset')
+   .reply(200, response.deployChangesForWAF);
+
+  before(async () => {
+    res = await fastly.deployChangesForWAF('rfjn9II8V21LSeEgyMT9x');
+  });
+
+  it('response should be a status 200', () => {
+    expect(res.status).toBe(200);
+  });
+
+  it('response body should exist', () => {
+    expect(res.data).toExist();
+  });
+
+  it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x', () => {
+    console.log(res.data)
+    expect(res.data.data.id).toBe("rfjn9II8V21LSeEgyMT9x");
+  });
+
+  it('response should contain type "ruleset"', () => {
+    expect(res.data.data.type).toBe("ruleset");
+  });
+
+});

--- a/test/getWAFs.test.js
+++ b/test/getWAFs.test.js
@@ -1,16 +1,13 @@
 'use strict';
 
-require('dotenv').config({path: require('path').join(__dirname, '../src/.env')});
 const nock = require('nock');
 const expect = require('expect');
 const config = require('../src/config');
 const fastlyPromises = require('../src/index');
 const response = require('./response/getWAFs.response');
 
-const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
-
 describe('#getWAFs', () => {
-  const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', '79CEhEeP8DKPQQGTXokV5M');
   let res;
 
   nock(config.mainEntryPoint)
@@ -19,12 +16,10 @@ describe('#getWAFs', () => {
 
   before(async () => {
     res = await fastly.getWAFs('9');
-    console.log(res.data)
   });
 
   it('response should be a status 200', () => {
     expect(res.status).toBe(200);
-    //console.log(res.data.data)
   });
 
   it('response body should exist', () => {

--- a/test/getWAFs.test.js
+++ b/test/getWAFs.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+require('dotenv').config({path: require('path').join(__dirname, '../src/.env')});
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/getWAFs.response');
+
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+
+describe('#getWAFs', () => {
+    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGiXokV5M');
+    let res;
+
+    nock(config.mainEntryPoint)
+        .get('/service/79CEhEeP8DKPQQGiXokV5M/version/9/wafs')
+        .reply(200, response.getWAFs);
+
+    before(async () => {
+        res = await fastly.getWAFs('9');
+    });
+
+    it('response should be a status 200', () => {
+        expect(res.status).toBe(200);
+        //console.log(res.data.data)
+    });
+
+    it('response body should exist', () => {
+        expect(res.data).toExist();
+    });
+
+    it('response body should be an array', () => {
+        expect(Array.isArray(res.data.data)).toBe(true);
+    });
+
+    it('response should contain WAF ID rfjm9II8V21LSeEgyMi9x', () => {
+        expect(res.data.data[0].id).toBe("rfjm9II8V21LSeEgyMi9x");
+    });
+
+    it('response body should contain properties', () => {
+        expect(res.data).toIncludeKeys(['links','meta']);
+    });
+
+});

--- a/test/getWAFs.test.js
+++ b/test/getWAFs.test.js
@@ -10,15 +10,16 @@ const response = require('./response/getWAFs.response');
 const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
 
 describe('#getWAFs', () => {
-    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGiXokV5M');
+    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
     let res;
 
     nock(config.mainEntryPoint)
-        .get('/service/79CEhEeP8DKPQQGiXokV5M/version/9/wafs')
+        .get('/service/79CEhEeP8DKPQQGTXokV5M/version/9/wafs')
         .reply(200, response.getWAFs);
 
     before(async () => {
         res = await fastly.getWAFs('9');
+        console.log(res.data)
     });
 
     it('response should be a status 200', () => {
@@ -34,8 +35,8 @@ describe('#getWAFs', () => {
         expect(Array.isArray(res.data.data)).toBe(true);
     });
 
-    it('response should contain WAF ID rfjm9II8V21LSeEgyMi9x', () => {
-        expect(res.data.data[0].id).toBe("rfjm9II8V21LSeEgyMi9x");
+    it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x', () => {
+        expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x");
     });
 
     it('response body should contain properties', () => {

--- a/test/getWAFs.test.js
+++ b/test/getWAFs.test.js
@@ -19,7 +19,7 @@ describe('#getWAFs', () => {
 
   before(async () => {
     res = await fastly.getWAFs('9');
-    console.log(res.data)
+    //console.log(res.data)
   });
 
   it('response should be a status 200', () => {

--- a/test/getWAFs.test.js
+++ b/test/getWAFs.test.js
@@ -10,37 +10,37 @@ const response = require('./response/getWAFs.response');
 const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
 
 describe('#getWAFs', () => {
-    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
-    let res;
+  const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
+  let res;
 
-    nock(config.mainEntryPoint)
-        .get('/service/79CEhEeP8DKPQQGTXokV5M/version/9/wafs')
-        .reply(200, response.getWAFs);
+  nock(config.mainEntryPoint)
+   .get('/service/79CEhEeP8DKPQQGTXokV5M/version/9/wafs')
+   .reply(200, response.getWAFs);
 
-    before(async () => {
-        res = await fastly.getWAFs('9');
-        console.log(res.data)
-    });
+  before(async () => {
+    res = await fastly.getWAFs('9');
+    console.log(res.data)
+  });
 
-    it('response should be a status 200', () => {
-        expect(res.status).toBe(200);
-        //console.log(res.data.data)
-    });
+  it('response should be a status 200', () => {
+    expect(res.status).toBe(200);
+    //console.log(res.data.data)
+  });
 
-    it('response body should exist', () => {
-        expect(res.data).toExist();
-    });
+  it('response body should exist', () => {
+    expect(res.data).toExist();
+  });
 
-    it('response body should be an array', () => {
-        expect(Array.isArray(res.data.data)).toBe(true);
-    });
+  it('response body should be an array', () => {
+    expect(Array.isArray(res.data.data)).toBe(true);
+  });
 
-    it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x', () => {
-        expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x");
-    });
+  it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x', () => {
+    expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x");
+  });
 
-    it('response body should contain properties', () => {
-        expect(res.data).toIncludeKeys(['links','meta']);
-    });
+  it('response body should contain properties', () => {
+    expect(res.data).toIncludeKeys(['links', 'meta']);
+  });
 
 });

--- a/test/getWafRules.test.js
+++ b/test/getWafRules.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/getWafRules.response');
+
+describe('#getWafRules', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', "79CEhEeP8DKPQQGiXokV5M");
+  let res;
+
+  nock(config.mainEntryPoint)
+   .log(console.log)
+   .get('/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/rule_statuses?filter[status]=log&page[size]=200&page[number]=1')
+   .reply(200, response.getWafRules);
+
+  before(async () => {
+    res = await fastly.getWafRules('rfjm9II8V21LSeEgyMi9x', 'log', '1');
+  });
+
+  it('response should be a status 200', () => {
+    expect(res.status).toBe(200);
+  });
+
+  it('response body should exist', () => {
+    expect(res.data).toExist();
+  });
+
+  it('response body should be an array', () => {
+    expect(Array.isArray(res.data.data)).toBe(true);
+  });
+
+  it('response body should contain properties', () => {
+    expect(res.data).toIncludeKeys(['data', 'links', 'meta']);
+  });
+
+  it('response should contain a status of log', () => {
+    expect(res.data.data[0].attributes.status).toBe("log");
+  });
+
+  it('response should only be 1 page long', () => {
+    expect(res.data.meta.total_pages).toBe(1);
+  });
+
+});

--- a/test/getWafRulesByTags.test.js
+++ b/test/getWafRulesByTags.test.js
@@ -4,18 +4,19 @@ const nock = require('nock');
 const expect = require('expect');
 const config = require('../src/config');
 const fastlyPromises = require('../src/index');
-const response = require('./response/getWafRules.response');
+const response = require('./response/getWafRulesByTags.response');
 
-describe('#getWafRules', () => {
-  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', "79CEhEeP8DKPQQGiXokV5M");
+describe('#getWafRulesByTags', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', '79CEhEeP8DKPQQGTXokV5M');
   let res;
 
   nock(config.mainEntryPoint)
-   .get('/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/rule_statuses?filter[status]=log&page[size]=200&page[number]=1')
-   .reply(200, response.getWafRules);
+    //.log(console.log)
+    .get('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[size]=200&page[number]=1')
+    .reply(200, response.getWafRulesByTags);
 
   before(async () => {
-    res = await fastly.getWafRules('rfjm9II8V21LSeEgyMi9x', 'log', '1');
+    res = await fastly.getWafRulesByTags('rfjn9II8V21LSeEgyMT9x','language-css','1');
   });
 
   it('response should be a status 200', () => {
@@ -34,8 +35,8 @@ describe('#getWafRules', () => {
     expect(res.data).toIncludeKeys(['data', 'links', 'meta']);
   });
 
-  it('response should contain a status of log', () => {
-    expect(res.data.data[0].attributes.status).toBe("log");
+  it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x-2077876', () => {
+    expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x-2077876");
   });
 
   it('response should only be 1 page long', () => {

--- a/test/response/deployChangesForWAF.response.js
+++ b/test/response/deployChangesForWAF.response.js
@@ -1,0 +1,13 @@
+'use strict';
+module.exports.deployChangesForWAF =
+{
+   "data":{
+      "id":"rfjn9II8V21LSeEgyMT9x",
+      "type":"ruleset"
+   },
+   "links":{
+      "related":{
+         "href":"https://api.fastly.com/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/update_statuses/4N0FXLCdRDk8KkyAZ6Bd8N"
+      }
+   }
+};

--- a/test/response/getWAFs.response.js
+++ b/test/response/getWAFs.response.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports.getWAFs =
+    {
+        "data": [
+            {
+                "attributes": {
+                    "last_push": "2017-11-30T14:24:58Z",
+                    "prefetch_condition": "WAF_Prefetch",
+                    "response": "WAF_Response",
+                    "rule_statuses_block_count": 0,
+                    "rule_statuses_disabled_count": 26,
+                    "rule_statuses_log_count": 989,
+                    "service_id": "79CEhEeP8DKPQQGiXokV5M",
+                    "version": 9
+                },
+                "id": "rfjm9II8V21LSeEgyMi9x",
+                "type": "waf"
+            }
+        ],
+        "links": {
+            "first": "http://api.fastly.com/service/79CEhEeP8DKPQQGiXokV5M/version/9/wafs?page[number]=1&page[size]=100",
+            "last": "http://api.fastly.com/service/79CEhEeP8DKPQQGiXokV5M/version/9/wafs?page[number]=1&page[size]=100"
+        },
+        "meta": {
+            "current_page": 1,
+            "per_page": 100,
+            "record_count": 1,
+            "total_pages": 1
+        }
+    };

--- a/test/response/getWAFs.response.js
+++ b/test/response/getWAFs.response.js
@@ -7,13 +7,13 @@ module.exports.getWAFs =
                     "last_push": "2017-11-30T14:24:58Z",
                     "prefetch_condition": "WAF_Prefetch",
                     "response": "WAF_Response",
-                    "rule_statuses_block_count": 0,
-                    "rule_statuses_disabled_count": 26,
-                    "rule_statuses_log_count": 989,
-                    "service_id": "79CEhEeP8DKPQQGiXokV5M",
+                    "rule_statuses_block_count": 999,
+                    "rule_statuses_disabled_count": 999,
+                    "rule_statuses_log_count": 999,
+                    "service_id": "79CEhEeP8DKPQQGTXokV5M",
                     "version": 9
                 },
-                "id": "rfjm9II8V21LSeEgyMi9x",
+                "id": "rfjn9II8V21LSeEgyMT9x",
                 "type": "waf"
             }
         ],

--- a/test/response/getWafRules.response.js
+++ b/test/response/getWafRules.response.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports.getWafRules =
+    {
+        "data": [
+            {
+                "id": "rfjm9II8V21LSeEgyMi9x-2043589",
+                "type": "rule_status",
+                "attributes": {
+                    "status": "log"
+                }
+            }
+        ],
+        "links": {
+            "last": "http://api.fastly.com/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/rule_statuses?filter[status]=log&page[number]=1&page[size]=200",
+            "first": "http://api.fastly.com/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/rule_statuses?filter[status]=log&page[number]=1&page[size]=200"
+        },
+        "meta": {
+            "current_page": 1,
+            "per_page": 200,
+            "record_count": 27,
+            "total_pages": 1
+        }
+    };

--- a/test/response/getWafRulesByTags.response.js
+++ b/test/response/getWafRulesByTags.response.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports.getWafRulesByTags =
+{
+  "data": [
+    {
+      "id": "rfjn9II8V21LSeEgyMT9x-2077876",
+      "type": "rule_status",
+      "attributes": {
+        "status": "block"
+      }
+    }
+  ],
+  "links": {
+    "last": "http://api.fastly.com/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=100",
+    "first": "http://api.fastly.com/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=100"
+  },
+  "meta": {
+    "current_page": 1,
+    "per_page": 100,
+    "record_count": 1,
+    "total_pages": 1
+  }
+};

--- a/test/response/updateRules.response.js
+++ b/test/response/updateRules.response.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports.updateRules = {
+  "data": {
+    "id": "rfjn9II8V21LSeEgyMT9x-2071357",
+    "type": "rule_status",
+    "attributes": {
+      "status": "disabled"
+    },
+    "relationships": {
+      "rule": {
+        "data": {
+          "id": "2071357",
+          "type": "rule"
+        }
+      },
+      "waf": {
+        "data": {
+          "id": "rfjn9II8V21LSeEgyMT9x",
+          "type": "waf"
+        }
+      }
+    }
+  }
+};

--- a/test/response/updateTags.response.js
+++ b/test/response/updateTags.response.js
@@ -1,0 +1,46 @@
+'use strict';
+module.exports.updateTags = {
+    "data": [
+        {
+            "id": "rfjn9II8V21LSeEgyMT9x-905100",
+            "type": "rule_status",
+            "attributes": {
+                "status": "block"
+            },
+            "relationships": {
+                "rule": {
+                    "data": {
+                        "id": "905100",
+                        "type": "rule"
+                    }
+                },
+                "waf": {
+                    "data": {
+                        "id": "rfjn9II8V21LSeEgyMT9x",
+                        "type": "waf"
+                    }
+                }
+            }
+        },
+        {
+            "id": "rfjn9II8V21LSeEgyMT9x-905110",
+            "type": "rule_status",
+            "attributes": {
+                "status": "block"
+            },
+            "relationships": {
+                "rule": {
+                    "data": {
+                        "id": "905110",
+                        "type": "rule"
+                    }
+                },
+                "waf": {
+                    "data": {
+                        "id": "rfjn9II8V21LSeEgyMT9x",
+                        "type": "waf"
+                    }
+                }
+            }
+        }] //and so on for all the rule(s) in a tag in WAF
+};

--- a/test/updateRules.test.js
+++ b/test/updateRules.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+require('dotenv').config({path: require('path').join(__dirname, '../src/.env')});
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/updateRules.response');
+
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+
+describe('#UpdateRules', () => {
+  const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
+  let res;
+
+  nock(config.mainEntryPoint)
+    .patch('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rules/2071357/rule_status', () => true)
+    .times(2)
+    .reply(200, response.updateRules);
+
+  before(async () => {
+    res = await fastly.updateRules("rfjn9II8V21LSeEgyMT9x", "disabled", ["2071357","2071357"]);
+    //console.log(res)
+  });
+
+  it('response body should exist', () => {
+    //console.log(res);
+    expect(res).toExist();
+  });
+
+  it('response should be an array of objects', () => {
+    res.forEach(item => {
+      expect(item).toBeA('object');
+    });
+  });
+
+  it('all responses should have a status 200', () => {
+    res.forEach(item => {
+      expect(item.status).toBe(200);
+    });
+  });
+
+  it('responses should have "data" field containing properties', () => {
+    res.forEach(item => {
+      //console.log(item.data.data)
+      expect(item.data.data).toIncludeKeys([
+        'id',
+        'attributes',
+        'type',
+        'relationships'
+      ]);
+    });
+  });
+
+  it('responses should have status as disabled', () => {
+    res.forEach(item => {
+      expect(item.data.data.id).toBe("rfjn9II8V21LSeEgyMT9x-2071357");
+      expect(item.data.data.attributes.status).toBe("disabled");
+    });
+  });
+});

--- a/test/updateTags.test.js
+++ b/test/updateTags.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+require('dotenv').config({path: require('path').join(__dirname, '../src/.env')});
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/updateTags.response');
+
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+
+describe('#UpdateTags', () => {
+    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
+    let res;
+
+    nock(config.mainEntryPoint)
+        .post('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses', () => true)
+        .times(10)
+        .reply(200, response.updateTags);
+
+    before(async () => {
+        res = await fastly.updateTags("rfjn9II8V21LSeEgyMT9x", "block");
+        //console.log(res)
+    });
+
+    it('response body should exist', () => {
+        expect(res).toExist();
+    });
+
+    it('response should be an array of objects', () => {
+        res.forEach(item => {
+            expect(item).toBeA('object');
+        });
+    });
+
+    it('all responses should have a status 200', () => {
+        res.forEach(item => {
+            expect(item.status).toBe(200);
+        });
+    });
+
+    it('responses should have "data" field containing properties', () => {
+        res.forEach(item => {
+            expect(item.data.data[0]).toIncludeKeys([
+                'id',
+                'attributes',
+                'relationships'
+            ]);
+        });
+    });
+
+    it('responses should have status as blocked', () => {
+        res.forEach(item => {
+            item.data.data.forEach(subitem => {
+                console.log(subitem.attributes.status);
+                expect(subitem.attributes.status).toBe("block");
+            });
+        });
+    });
+
+});

--- a/test/updateTags.test.js
+++ b/test/updateTags.test.js
@@ -52,7 +52,7 @@ describe('#UpdateTags', () => {
   it('responses should have status as blocked', () => {
     res.forEach(item => {
       item.data.data.forEach(subitem => {
-        console.log(subitem.attributes.status);
+        //console.log(subitem.attributes.status);
         expect(subitem.attributes.status).toBe("block");
       });
     });

--- a/test/updateTags.test.js
+++ b/test/updateTags.test.js
@@ -10,52 +10,52 @@ const response = require('./response/updateTags.response');
 const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
 
 describe('#UpdateTags', () => {
-    const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
-    let res;
+  const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
+  let res;
 
-    nock(config.mainEntryPoint)
-        .post('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses', () => true)
-        .times(10)
-        .reply(200, response.updateTags);
+  nock(config.mainEntryPoint)
+   .post('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses', () => true)
+   .times(10)
+   .reply(200, response.updateTags);
 
-    before(async () => {
-        res = await fastly.updateTags("rfjn9II8V21LSeEgyMT9x", "block");
-        //console.log(res)
+  before(async () => {
+    res = await fastly.updateTags("rfjn9II8V21LSeEgyMT9x", "block");
+    //console.log(res)
+  });
+
+  it('response body should exist', () => {
+    expect(res).toExist();
+  });
+
+  it('response should be an array of objects', () => {
+    res.forEach(item => {
+      expect(item).toBeA('object');
     });
+  });
 
-    it('response body should exist', () => {
-        expect(res).toExist();
+  it('all responses should have a status 200', () => {
+    res.forEach(item => {
+      expect(item.status).toBe(200);
     });
+  });
 
-    it('response should be an array of objects', () => {
-        res.forEach(item => {
-            expect(item).toBeA('object');
-        });
+  it('responses should have "data" field containing properties', () => {
+    res.forEach(item => {
+      expect(item.data.data[0]).toIncludeKeys([
+        'id',
+        'attributes',
+        'relationships'
+      ]);
     });
+  });
 
-    it('all responses should have a status 200', () => {
-        res.forEach(item => {
-            expect(item.status).toBe(200);
-        });
+  it('responses should have status as blocked', () => {
+    res.forEach(item => {
+      item.data.data.forEach(subitem => {
+        console.log(subitem.attributes.status);
+        expect(subitem.attributes.status).toBe("block");
+      });
     });
-
-    it('responses should have "data" field containing properties', () => {
-        res.forEach(item => {
-            expect(item.data.data[0]).toIncludeKeys([
-                'id',
-                'attributes',
-                'relationships'
-            ]);
-        });
-    });
-
-    it('responses should have status as blocked', () => {
-        res.forEach(item => {
-            item.data.data.forEach(subitem => {
-                console.log(subitem.attributes.status);
-                expect(subitem.attributes.status).toBe("block");
-            });
-        });
-    });
+  });
 
 });

--- a/test/updateTags.test.js
+++ b/test/updateTags.test.js
@@ -13,14 +13,36 @@ describe('#UpdateTags', () => {
   const fastly = fastlyPromises(FASTLY_API_TOKEN, '79CEhEeP8DKPQQGTXokV5M');
   let res;
 
-  nock(config.mainEntryPoint)
-   .post('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses', () => true)
-   .times(10)
-   .reply(200, response.updateTags);
+  const createUpdateTagsStub = (bodyTest = '*') => {
+    return nock(config.mainEntryPoint)
+      .post('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses', bodyTest)
+      .times(10)
+      .reply(200, response.updateTags);
+  };
+
+  const makeUpdateTagsRequest = async (force) => {
+    res = await fastly.updateTags("rfjn9II8V21LSeEgyMT9x", "block", undefined, force);
+  };
+
+  createUpdateTagsStub(() => true);
 
   before(async () => {
-    res = await fastly.updateTags("rfjn9II8V21LSeEgyMT9x", "block");
+    await makeUpdateTagsRequest();
     //console.log(res)
+  });
+
+  it('request body shouldn\'t contain force key:value when value is set to false', async () => {
+    nock.cleanAll();
+    const scope = createUpdateTagsStub((body) => body.data.attributes && (typeof body.data.attributes.force) === 'undefined');
+    await makeUpdateTagsRequest();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('request body should contain force key:value when value is set to true', async () => {
+    nock.cleanAll();
+    const scope = createUpdateTagsStub((body) => body.data.attributes && body.data.attributes.force === true);
+    await makeUpdateTagsRequest(true);
+    expect(scope.isDone()).toBe(true);
   });
 
   it('response body should exist', () => {


### PR DESCRIPTION
Added 2 new endpoints from the WAF API.

1. [Get WAFs](https://docs.fastly.com/api/waf#waf_firewall_989adbdf8ec7257d37283e21ae2391f2): Lists all the WAFs associated with the service, given the service ID and the version. 
2. [Update WAF Rule Status by Tags](https://docs.fastly.com/api/waf#waf_rule_status_9b551e33b53dedfbee3f6ac6e2a56e2a): updates the status of the WAF rule(s) by Tags(s). 

Added tests and checks. 