### PR TITLE
Update axios to v0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "semantic-release": "^6.3.6"
   },
   "dependencies": {
-    "axios": "0.16.2"
+    "axios": "0.21.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Addresses the vulnerability described in https://github.com/axios/axios/pull/3410

There are two breaking changes between axios 0.16 and 0.21 according to https://github.com/axios/axios/blob/master/CHANGELOG.md. I couldn't find any occurrences of either, and the tests are passing